### PR TITLE
Allow searching on Postgres

### DIFF
--- a/lib/obanalyze/oban_jobs.ex
+++ b/lib/obanalyze/oban_jobs.ex
@@ -57,9 +57,17 @@ defmodule Obanalyze.ObanJobs do
   defp filter(query, term) do
     like = "%#{term}%"
 
-    from oj in query,
-      where: like(oj.worker, ^like),
-      or_where: like(oj.args, ^like)
+    case Oban.config() do
+      %{engine: Oban.Engines.Basic} ->
+        from oj in query,
+          where: ilike(oj.worker, ^like),
+          or_where: ilike(type(oj.args, :string), ^like)
+
+      %{engine: Oban.Engines.Lite} ->
+        from oj in query,
+          where: like(oj.worker, ^like),
+          or_where: like(oj.args, ^like)
+    end
   end
 
   defp jobs_count_query(job_state) do

--- a/lib/obanalyze/oban_jobs.ex
+++ b/lib/obanalyze/oban_jobs.ex
@@ -63,7 +63,7 @@ defmodule Obanalyze.ObanJobs do
           where: ilike(oj.worker, ^like),
           or_where: ilike(type(oj.args, :string), ^like)
 
-      %{engine: Oban.Engines.Lite} ->
+      _ ->
         from oj in query,
           where: like(oj.worker, ^like),
           or_where: like(oj.args, ^like)


### PR DESCRIPTION
Hi @egze 

This patch changes the search implementation to explicitly cast the jsonb args column to `text` before passing it to `like/2`, as PostgreSQL (at least version <=15) does not support `jsonb ~~ text` like sqlite does.

I'd also like to also switch the `like` to `ilike` for Postgres as it defaults to case-sensitive search, but not sure how to get the adapter from `Oban.Repo`.

Great work, your library hits a sweet spot for me with its functionality & scope :+1: 