### PR TITLE
Customizable Oban name

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -1,14 +1,14 @@
 defmodule Obanalyze.MixProject do
   use Mix.Project
 
-  @version "1.4.1"
+  @version "1.4.2"
   @source_url "https://github.com/egze/obanalyze"
 
   def project do
     [
       app: :obanalyze,
       version: @version,
-      elixir: "~> 1.12",
+      elixir: "~> 1.13",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Uses compile time env to configure a specific named instance of Oban for which to use for all calls to Oban - defaults to `Oban` 

closes #12
